### PR TITLE
trytond : Optionaly ignore function fields in ir.model.graph

### DIFF
--- a/trytond/ir/view/model_print_model_graph_start_form.xml
+++ b/trytond/ir/view/model_print_model_graph_start_form.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0"?>
 <!-- This file is part of Tryton.  The COPYRIGHT file at the top level of
 this repository contains the full copyright notices and license terms. -->
-<form string="Print Model Graph" col="2">
+<form string="Print Model Graph" col="4">
     <label name="level"/>
     <field name="level"/>
+    <label name="ignore_function"/>
+    <field name="ignore_function"/>
     <label name="filter"/>
-    <field name="filter"/>
+    <field name="filter" colspan="3"/>
 </form>


### PR DESCRIPTION
Function fields may render the ir.model.graph report unusable if there are a
lot of them, and if the objective is a database visualisation tool.

Fix #4940
