### PR TITLE
trytond : Trigger post_init after setup

### DIFF
--- a/trytond/pool.py
+++ b/trytond/pool.py
@@ -90,7 +90,9 @@ class Pool(object):
 
     @staticmethod
     def register_post_init_hooks(*hooks, **kwargs):
-        Pool._init_hooks[kwargs['module']] = hooks
+        if kwargs['module'] not in Pool._init_hooks:
+            Pool._init_hooks[kwargs['module']] = []
+        Pool._init_hooks[kwargs['module']] += hooks
 
     @classmethod
     def start(cls):
@@ -166,7 +168,6 @@ class Pool(object):
                     lang=lang)
             if restart:
                 self.init()
-            self.post_init()
 
     def post_init(self):
         for hook in self._post_init_calls[self.database_name]:
@@ -247,6 +248,7 @@ class Pool(object):
                 cls.__setup__()
             for cls in lst:
                 cls.__post_setup__()
+        self.post_init()
 
 
 def isregisteredby(obj, module, type_='model'):


### PR DESCRIPTION
Post init hooks should be triggered at the end of Pool.setup in order to be
sure they are properly called when upgrading the database.