### PR TITLE
trytond : Add update parameter to post init hooks

### DIFF
--- a/trytond/modules/__init__.py
+++ b/trytond/modules/__init__.py
@@ -229,6 +229,7 @@ def load_module_graph(graph, pool, update=None, lang=None):
             classes = pool.fill(module)
             if update:
                 pool.setup(classes)
+                pool.post_init(module)
             package_state = module2state.get(module, 'not activated')
             if (is_module_to_install(module, update)
                     or (update
@@ -299,6 +300,7 @@ def load_module_graph(graph, pool, update=None, lang=None):
 
         if not update:
             pool.setup()
+            pool.post_init(None)
 
         for model_name in models_to_update_history:
             model = pool.get(model_name)

--- a/trytond/pool.py
+++ b/trytond/pool.py
@@ -169,11 +169,9 @@ class Pool(object):
             if restart:
                 self.init()
 
-    def post_init(self):
+    def post_init(self, update):
         for hook in self._post_init_calls[self.database_name]:
-            logging.getLogger('modules').info('Running post init hook %s' %
-                hook.__name__)
-            hook(self)
+            hook(self, update)
 
     def get(self, name, type='model'):
         '''
@@ -248,7 +246,6 @@ class Pool(object):
                 cls.__setup__()
             for cls in lst:
                 cls.__post_setup__()
-        self.post_init()
 
 
 def isregisteredby(obj, module, type_='model'):


### PR DESCRIPTION
Some hooks will not be necessary on updates, others will only be required when
updating some modules, etc... So we add an 'update' argument to hooks so that
it becomes possible to activate the hook or not depending on the context.

Consequently, we move the logging part from the post_init method to inside the
hook, so the log is not filled with hooks which aren't actually triggered.