### PR TITLE
report: avoid coog server tail crash when logging unoconv binaries

### DIFF
--- a/trytond/report/report.py
+++ b/trytond/report/report.py
@@ -272,9 +272,6 @@ class Report(URLMixin, PoolBase):
                 logger.info('unoconv.stdout : ' + stdoutdata)
                 logger.error('unoconv.stderr : ' + stderrdata)
                 raise Exception(stderrdata)
-            else:
-                logger.debug('unoconv.stdout : ' + stdoutdata)
-                logger.debug('unoconv.stderr : ' + stderrdata)
             return oext, stdoutdata
         finally:
             os.remove(path)


### PR DESCRIPTION
Fix #6185