### PR TITLE
Add _datetime_exclude to private context keys exception

### DIFF
--- a/trytond/rpc.py
+++ b/trytond/rpc.py
@@ -37,7 +37,7 @@ class RPC(object):
             if key == '_timestamp':
                 timestamp = context[key]
             # Remove all private keyword but _datetime for history
-            if key.startswith('_') and key != '_datetime':
+            if key.startswith('_') and not key.startswith('_datetime'):
                 del context[key]
         if self.instantiate is not None:
 


### PR DESCRIPTION
It is required that the _datetime_exclude key be True to read records
"right before" something happens, but the server actually drops the key
since it is considered private.

Fix #6582