### PR TITLE
trytond : Do not to try to set reverse O2M field for function fields

### DIFF
--- a/trytond/model/modelstorage.py
+++ b/trytond/model/modelstorage.py
@@ -1432,7 +1432,7 @@ class ModelStorage(Model):
                         if field._type == 'one2many':
                             # Don't store old target link
                             if field.field:
-                                # Ignore if Function field
+                                # JCA : Ignore if Function field
                                 setattr(target, field.field, None)
                         to_create.append(target._save_values)
                     else:

--- a/trytond/model/modelstorage.py
+++ b/trytond/model/modelstorage.py
@@ -1431,7 +1431,9 @@ class ModelStorage(Model):
                     if target.id is None or target.id < 0:
                         if field._type == 'one2many':
                             # Don't store old target link
-                            setattr(target, field.field, None)
+                            if field.field:
+                                # Ignore if Function field
+                                setattr(target, field.field, None)
                         to_create.append(target._save_values)
                     else:
                         if target.id in to_remove:


### PR DESCRIPTION
The `_save_values` method checks and sets the reverse field of O2M fields if necessary, but it does not check whether the field is a function field. So this may causes errors, because `field.field` is `None`.