### PR TITLE
trytond : Only load rec_names for saved instances

### DIFF
--- a/trytond/model/modelview.py
+++ b/trytond/model/modelview.py
@@ -739,11 +739,11 @@ class ModelView(Model):
                 continue
             if field._type in ('many2one', 'one2one', 'reference'):
                 if value:
-                    if isinstance(value, ModelStorage):
-                        changed['%s.rec_name' % fname] = value.rec_name
-                    if value.id is None:
+                    if value.id is None or value.id < 0:
                         # Don't consider temporary instance as a change
                         continue
+                    if isinstance(value, ModelStorage):
+                        changed['%s.rec_name' % fname] = value.rec_name
                     if field._type == 'reference':
                         value = str(value)
                     else:


### PR DESCRIPTION
The rec_name may not be available for newly created instances, and
we should not get it anyway even if it was because the main data
will not be returned