### PR TITLE
trytond : Always call post_init(None)

### DIFF
--- a/trytond/modules/__init__.py
+++ b/trytond/modules/__init__.py
@@ -299,7 +299,7 @@ def load_module_graph(graph, pool, update=None, lang=None):
 
         if not update:
             pool.setup()
-            pool.post_init(None)
+        pool.post_init(None)
 
         for model_name in models_to_update_history:
             model = pool.get(model_name)


### PR DESCRIPTION
In tests, the server is called right after being updated. In
this case, the post_init method must be called anyway for hooks
that are only called when not updating