### PR TITLE
tests: fix concurrent access when dropping database

### DIFF
--- a/trytond/tests/test_tryton.py
+++ b/trytond/tests/test_tryton.py
@@ -7,6 +7,7 @@ import unittest
 import doctest
 import re
 import subprocess
+import time
 from itertools import chain
 import operator
 from functools import wraps
@@ -516,7 +517,18 @@ def drop_db(name=DB_NAME):
         with Transaction().start(
                 None, 0, close=True, autocommit=True, _nocache=True) \
                 as transaction:
-            database.drop(transaction.connection, name)
+            # PJA: fix concurrent access when dropping database
+            attempt = 0
+            max_attempts = 10
+            while True:
+                attempt += 1
+                try:
+                    database.drop(transaction.connection, name)
+                except:
+                    if attempt > max_attempts:
+                        raise
+                    else:
+                        time.sleep(3)
             Pool.stop(name)
             Cache.drop(name)
 


### PR DESCRIPTION
A simply "elegant" solution to the concurrent access errors causing tests to fail