### PR TITLE
No need to query db when no translatable fields

### DIFF
--- a/trytond/model/modelsql.py
+++ b/trytond/model/modelsql.py
@@ -1116,7 +1116,9 @@ class ModelSQL(ModelStorage):
                         exception, {}, transaction=transaction)
                 raise
 
-        Translation.delete_ids(cls.__name__, 'model', ids)
+        translated = [f for f in cls._fields if getattr(f, 'translate', False)]
+        if translated:
+            Translation.delete_ids(cls.__name__, 'model', ids)
 
         cls._insert_history(ids, deleted=True)
 


### PR DESCRIPTION
Remontée lors de l'analyse des requêtes: quand on delete un paquet d'id, la requête prend du temps pour rien faire
=> Monter à Trytond