### PR TITLE
Add cache for check_xml_record

### DIFF
--- a/trytond/ir/model.py
+++ b/trytond/ir/model.py
@@ -1021,6 +1021,7 @@ class ModelData(ModelSQL, ModelView):
     out_of_sync = fields.Function(fields.Boolean('Out of Sync'),
         'get_out_of_sync', searcher='search_out_of_sync')
     _get_id_cache = Cache('ir_model_data.get_id', context=False)
+    _has_model_cache = Cache('ir_model_data.has_model', context=False)
 
     @classmethod
     def __setup__(cls):
@@ -1072,10 +1073,33 @@ class ModelData(ModelSQL, ModelView):
         return [('id', 'in', query)]
 
     @classmethod
+    def create(cls, *args):
+        super(ModelData, cls).create(*args)
+        cls._has_model_cache.clear()
+
+    @classmethod
     def write(cls, data, values, *args):
         super(ModelData, cls).write(data, values, *args)
         # Restart the cache for get_id
         cls._get_id_cache.clear()
+        cls._has_model_cache.clear()
+
+    @classmethod
+    def delete(cls, records):
+        super(ModelData, cls).delete(records)
+        cls._has_model_cache.clear()
+
+    @classmethod
+    def has_model(cls, model):
+        models = cls._has_model_cache.get(None)
+        if models is None:
+            table = cls.__table__()
+            cursor = Transaction().connection.cursor()
+
+            cursor.execute(*table.select(table.model, group_by=[table.model]))
+            models = [m[0] for m in cursor.fetchall()]
+            cls._has_model_cache.set(None, models)
+        return model in models
 
     @classmethod
     def get_id(cls, module, fs_id):

--- a/trytond/model/modelstorage.py
+++ b/trytond/model/modelstorage.py
@@ -795,7 +795,8 @@ class ModelStorage(Model):
         """
         ModelData = Pool().get('ir.model.data')
         # Allow root user to update/delete
-        if Transaction().user == 0:
+        if (Transaction().user == 0
+                or not ModelData.has_model(cls.__name__)):
             return True
         with Transaction().set_context(_check_access=False):
             models_data = ModelData.search([


### PR DESCRIPTION
This allows fast return when the checked model has no record in
ir.model.data which is the most common case. This allow to prevent to
search for non existing records.