### PR TITLE
iwc: fix inter worker communication (not trigger due to tryton changes)

### DIFF
--- a/trytond/ir/module.py
+++ b/trytond/ir/module.py
@@ -15,7 +15,6 @@ from trytond.pool import Pool
 from trytond.transaction import Transaction
 from trytond.pyson import Eval
 from trytond.rpc import RPC
-from trytond.iwc import broadcast_init_pool
 
 __all__ = [
     'Module', 'ModuleDependency', 'ModuleConfigWizardItem',
@@ -581,7 +580,6 @@ class ModuleActivateUpgrade(Wizard):
             lang = [x.code for x in langs]
         if update:
             pool.init(update=update, lang=lang)
-            broadcast_init_pool()
         return 'done'
 
 

--- a/trytond/iwc.py
+++ b/trytond/iwc.py
@@ -91,4 +91,6 @@ def stop():
         return
     logger.info('init_pool: %s stopping', get_worker_id())
     listener.stop()
+    del listener
     del broker
+    del no_redis

--- a/trytond/pool.py
+++ b/trytond/pool.py
@@ -104,9 +104,6 @@ class Pool(object):
                 classes.clear()
             cls._init_hooks = {}
             register_classes()
-            # AKE: inter-workers communication (start listener)
-            from trytond import iwc
-            iwc.start()
             cls._started = True
 
     @classmethod
@@ -151,9 +148,13 @@ class Pool(object):
         Set update to proceed to update
         lang is a list of language code to be updated
         '''
+        from trytond import iwc
         with self._lock:
+            # AKE: inter-workers communication (start listener)
+            iwc.start()
             if not self._started:
                 self.start()
+
         with self._locks[self.database_name]:
             # Don't reset pool if already init and not to update
             if not update and self._pool.get(self.database_name):
@@ -168,6 +169,8 @@ class Pool(object):
                     lang=lang, installdeps=installdeps)
             if restart:
                 self.init()
+            if update:
+                iwc.broadcast_init_pool(self.database_name)
 
     def post_init(self, update):
         for hook in self._post_init_calls[self.database_name]:

--- a/trytond/pool.py
+++ b/trytond/pool.py
@@ -148,9 +148,10 @@ class Pool(object):
         Set update to proceed to update
         lang is a list of language code to be updated
         '''
+        # AKE: inter-workers communication
         from trytond import iwc
         with self._lock:
-            # AKE: inter-workers communication (start listener)
+            # AKE: inter-workers communication
             iwc.start()
             if not self._started:
                 self.start()
@@ -169,6 +170,7 @@ class Pool(object):
                     lang=lang, installdeps=installdeps)
             if restart:
                 self.init()
+            # AKE: inter-workers communication
             if update:
                 iwc.broadcast_init_pool(self.database_name)
 


### PR DESCRIPTION
Fix #8760
- Listener creation moved from Pool.start to Pool.init (start is called before forking)
- Broadcast mooved from ir.module workflow to Pool.init (trytond-admin does not trigger workflow)
- worker pid is not safe to identify worker (multi-container, multi-host) => id = hostname-pid