### PR TITLE
trytond: Use FORBIDDEN code instead of unauthorized to avoid client crash

### DIFF
--- a/trytond/wsgi.py
+++ b/trytond/wsgi.py
@@ -41,7 +41,7 @@ class TrytondWSGI(object):
         if request.user_id:
             return wrapped(*args, **kwargs)
         else:
-            abort(httplib.UNAUTHORIZED)
+            abort(httplib.FORBIDDEN)
 
     def check_request_size(self, request, size=None):
         if request.method not in {'POST', 'PUT', 'PATCH'}:

--- a/trytond/wsgi.py
+++ b/trytond/wsgi.py
@@ -41,6 +41,8 @@ class TrytondWSGI(object):
         if request.user_id:
             return wrapped(*args, **kwargs)
         else:
+            # ABDC: Here we change the code from UNAUTHORIZED because it 
+            # is not properly handled by the client and causes a crash.
             abort(httplib.FORBIDDEN)
 
     def check_request_size(self, request, size=None):


### PR DESCRIPTION
Fix #9888