### PR TITLE
test_tryton: use module as default cache_name for db_cache

### DIFF
--- a/trytond/tests/test_tryton.py
+++ b/trytond/tests/test_tryton.py
@@ -230,7 +230,7 @@ class ModuleTestCase(unittest.TestCase):
         modules = [cls.module]
         if cls.extras:
             modules.extend(cls.extras)
-        activate_module(modules)
+        activate_module(modules, cache_name=cls.module)
         super(ModuleTestCase, cls).setUpClass()
 
     @classmethod


### PR DESCRIPTION
This is so that we can automatically add 'api' module the the extras of all module test case, while keeping a correct name for the db cache.