### PR TITLE
report: add 2 retries by default on calls to unoconv api

### DIFF
--- a/trytond/config.py
+++ b/trytond/config.py
@@ -76,6 +76,9 @@ class TrytonConfigParser(configparser.RawConfigParser):
         self.set('cache', 'uri', os.environ.get('TRYTOND_CACHE_URI', None))
         self.set('cache', 'coog_cache_size', 1024)
 
+        self.add_section('report')
+        self.set('report', 'unoconv_retry', 2)
+
         self.add_section('queue')
         self.set('queue', 'worker', False)
         self.add_section('ssl')


### PR DESCRIPTION
This is a workaround to
Fix #10833
while waiting for potential real fix on #14733