### PR TITLE
trytond: Make wsgi application pypy compatible

### DIFF
--- a/trytond/application.py
+++ b/trytond/application.py
@@ -6,7 +6,7 @@ import logging
 import threading
 from io import StringIO
 
-__all__ = ['app']
+__all__ = ['app', 'application']
 
 LF = '%(process)s %(thread)s [%(asctime)s] %(levelname)s %(name)s %(message)s'
 log_file = os.environ.get('WSGI_LOG_FILE')
@@ -44,3 +44,5 @@ if db_names:
         threads.append(thread)
     for thread in threads:
         thread.join()
+
+application = app

--- a/trytond/protocols/jsonrpc.py
+++ b/trytond/protocols/jsonrpc.py
@@ -194,7 +194,7 @@ class JSONProtocol:
 
         # AKE: log RPC method (uwsgi and header)
         if uwsgi:
-            uwsgi.set_logvar('rpc', parsed_data['method'])
+            uwsgi.set_logvar(b'rpc', parsed_data['method'].encode('utf-8'))
         headers = Headers()
         headers.add('RPC-Method', parsed_data['method'])
 


### PR DESCRIPTION
The pypy module of wsgi does not allow to specify the name
of the variable to use as the application, so we must
expose an 'application' attribute

Fix #00000