### PR TITLE
database: Manually close test connections

### DIFF
--- a/trytond/backend/postgresql/database.py
+++ b/trytond/backend/postgresql/database.py
@@ -322,6 +322,7 @@ class Database(DatabaseInterface):
                             ) as conn:
                         if self._test(conn, hostname=hostname):
                             res.append(db_name)
+                        conn.close()
                 except Exception:
                     logger.debug(
                         'Test failed for "%s"', db_name, exc_info=True)


### PR DESCRIPTION
Without this, the connections are not closed until
they are GC'ed, which can take some time.

Also, if there are tens of databases to scan, we
may exhaust the connection pool of the database

(actually @jmousset found this one almost at the same time)