### PR TITLE
PYSON's DateTime defaults to the current time in UTC

### DIFF
--- a/doc/ref/pyson.rst
+++ b/doc/ref/pyson.rst
@@ -218,7 +218,7 @@ Returns a date time object which represents the values of variables named by
 the *arguments* explained below.
 Missing values of arguments named by  ``year``, ``month``, ``day``, ``hour``,
 ``minute``, ``second``, ``microseconds`` take their defaults from ``start`` or
-the actual date and time.
+the actual date and time in UTC.
 When values of arguments named by ``delta_*`` are given, these are added  to
 the appropriate attributes in a date and time preserving manner.
 

--- a/trytond/pyson.py
+++ b/trytond/pyson.py
@@ -630,7 +630,7 @@ class DateTime(Date):
                 and not isinstance(now, datetime.datetime)):
             now = datetime.datetime.combine(now, datetime.time())
         if not isinstance(now, datetime.datetime):
-            now = datetime.datetime.now()
+            now = datetime.datetime.utcnow()
         return now + relativedelta(
             year=dct['y'],
             month=dct['M'],


### PR DESCRIPTION
Fix #17400