### PR TITLE
cache: Use non-reset caches if possible

### DIFF
--- a/trytond/cache.py
+++ b/trytond/cache.py
@@ -125,7 +125,7 @@ class MemoryCache(BaseCache):
         transaction = Transaction()
         dbname = transaction.database.name
         lower = self._transaction_lower.get(dbname, self._default_lower)
-        if (transaction in self._reset
+        if (self._name in self._reset.get(transaction, {})
                 or transaction.started_at < lower):
             try:
                 return self._transaction_cache[transaction]


### PR DESCRIPTION
Just checking the existence of the transaction in the
_reset dict is not enough because:

- The transaction may be here because it reset another cache
- It may have been already committed once, and the commit
forcefully adds the transaction in the cache