### PR TITLE
Use the same heuristic to compute backend full text search configuration for both operands

### DIFF
--- a/trytond/backend/postgresql/database.py
+++ b/trytond/backend/postgresql/database.py
@@ -663,13 +663,12 @@ class Database(DatabaseInterface):
             ToTsQuery = WebsearchToTsQuery
         else:
             ToTsQuery = PlainToTsQuery
-        if language:
-            config_name = self._search_full_text_language(language)
-            if not isinstance(query, TsQuery):
-                query = ToTsQuery(config_name, query)
-        else:
-            if not isinstance(query, TsQuery):
-                query = ToTsQuery(query)
+        if not isinstance(query, TsQuery):
+            if language:
+                config_name = self._search_full_text_language(language)
+            else:
+                config_name = 'simple'
+            query = ToTsQuery(config_name, query)
         return query
 
     def search_full_text(self, document, query):

--- a/trytond/tests/test_field_text.py
+++ b/trytond/tests/test_field_text.py
@@ -503,6 +503,21 @@ class FieldTextTestCase(unittest.TestCase, CommonTestCaseMixin):
                     'text': 'foobar',
                     })
 
+    @unittest.skipIf(backend.name == 'sqlite',
+        "SQLite does not have full text search")
+    @with_transaction()
+    def test_search_full_text(self):
+        "Test the full text search"
+        pool = Pool()
+        Model = pool.get('test.text')
+
+        sambreville, = Model.create([{
+                    'text': "Sambreville",
+                    }])
+        self.assertListEqual(Model.search([
+                    ('text', 'ilike', '%Sambreville%'),
+                    ]), [sambreville])
+
 
 class FieldTextTranslatedTestCase(unittest.TestCase, CommonTestCaseMixin):
     "Test Field Text Translated"


### PR DESCRIPTION
Fix #21775