### PR TITLE
Force named kwargs in activate_modules

### DIFF
--- a/trytond/tests/tools.py
+++ b/trytond/tests/tools.py
@@ -9,7 +9,7 @@ __all__ = ['activate_modules', 'set_user']
 
 
 # PKU add cache_file_name
-def activate_modules(modules, cache_file_name=None):
+def activate_modules(modules, *, cache_file_name=None):
     if isinstance(modules, str):
         modules = [modules]
     cache_name = cache_file_name or '-'.join(modules)


### PR DESCRIPTION
Fix #0

Pour éviter de futures confusions