### PR TITLE
Fallback name fix

### DIFF
--- a/trytond/backend/postgresql/database.py
+++ b/trytond/backend/postgresql/database.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import time
+import urllib.parse
 import warnings
 from collections import defaultdict
 from datetime import datetime
@@ -278,15 +279,15 @@ class Database(DatabaseInterface):
     @classmethod
     def _connection_params(cls, name):
         # JCA: psycopg2cff does not support mixing dsn and other parameters
-        uri = parse_uri(
-            config.get('database', 'uri') +
-            '?fallback_application_name=' + os.environ.get(
-                'TRYTOND_APPNAME', 'trytond')
-            )
+        uri = parse_uri(config.get('database', 'uri'))
+        qs = urllib.parse.parse_qs(uri.query)
+        qs['fallback_application_name'] = os.environ.get(
+            'TRYTOND_APPNAME', 'trytond')
+        query = urllib.parse.urlencode(qs, doseq=True)
         if uri.path and uri.path != '/':
             warnings.warn("The path specified in the URI will be overridden")
         params = {
-            'dsn': uri._replace(path=name).geturl(),
+            'dsn': uri._replace(path=name, query=query).geturl(),
             }
         return params
 

--- a/trytond/cache.py
+++ b/trytond/cache.py
@@ -160,7 +160,7 @@ class MemoryCache(BaseCache):
         transaction = Transaction()
         dbname = transaction.database.name
         lower = self._transaction_lower.get(dbname, self._default_lower)
-        if (transaction in self._reset
+        if (self._name in self._reset.get(transaction, set())
                 or transaction.started_at < lower):
             try:
                 return self._transaction_cache[transaction]

--- a/trytond/cache.py
+++ b/trytond/cache.py
@@ -160,7 +160,7 @@ class MemoryCache(BaseCache):
         transaction = Transaction()
         dbname = transaction.database.name
         lower = self._transaction_lower.get(dbname, self._default_lower)
-        if (self._name in self._reset.get(transaction, set())
+        if (transaction in self._reset
                 or transaction.started_at < lower):
             try:
                 return self._transaction_cache[transaction]


### PR DESCRIPTION
Le fix pour psycopgcffi ne fonctionne pas quand le DSN a déjà une query string.
Ce changement fix cela.