### PR TITLE
Add an explicit error message when a reference can't be found when inheriting from a view

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* Add an explicit error message when a reference can't be found when inheriting from a view
 * Enable the csv extraction of records the user does not have access to
 * Use singleton for TableHandler
 * Add authentication services

--- a/trytond/ir/ui/view.py
+++ b/trytond/ir/ui/view.py
@@ -283,7 +283,10 @@ class View(ModelSQL, ModelView):
         root_inherit = inherit.getroottree().getroot()
         for element in root_inherit:
             targets = tree.xpath(element.get('expr'))
-            assert targets
+            if not targets:
+                raise AttributeError(
+                    'Couldn\'t find tag (%s: %s) in parent view!'
+                    % (element.tag, element.get('expr')))
             for target in targets:
                 position = element.get('position', 'inside')
                 new_tree = getattr(cls, '_inherit_apply_%s' % position)(


### PR DESCRIPTION
Fix #PJAZZ-873